### PR TITLE
Fixed redefinition warning

### DIFF
--- a/EmonLib.h
+++ b/EmonLib.h
@@ -35,16 +35,13 @@
 // otherwise will default to 10 bits, as in regular Arduino-based boards.
 #if defined(__arm__)
 #define ADC_BITS    12
+#elif defined(ESP32)
+#define ADC_BITS    12
 #else
 #define ADC_BITS    10
 #endif
 
-#if defined(ESP32)
-#define ADC_BITS    12
-#endif
-
 #define ADC_COUNTS  (1<<ADC_BITS)
-
 
 class EnergyMonitor
 {


### PR DESCRIPTION
Merged the ADC_BITS ifdef statement, used an `#elif defined(ESP32)` instead of another `#if defined(ESP32)` statement
This way the compiler will not complain about redeclaring ADC_BITS.

The warning was this:
``` c++
.pio\libdeps\nodemcu-32s\EmonLib-esp32/EmonLib.h:43:0: warning: "ADC_BITS" redefined
 #define ADC_BITS    12
 ^
.pio\libdeps\nodemcu-32s\EmonLib-esp32/EmonLib.h:39:0: note: this is the location of the previous definition
 #define ADC_BITS    10
 ^
 ```